### PR TITLE
remove Google Analytics, fixes #4

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,17 +9,6 @@
 
     <link rel="stylesheet" href="flexboxgrid.min.css">
     <link rel="stylesheet" href="style.css">
-	
-	<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-21696353-41"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-21696353-41');
-</script>
-
 </head>
 
 <body>


### PR DESCRIPTION
You can't seriously put Google tracking on a website that tells you how evil Google is tracking you everywhere you go